### PR TITLE
docs: fix ci badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <div align="center">
 
 [![Version](https://img.shields.io/npm/v/clerc.svg)](https://npmjs.org/package/clerc)
-[![CI](https://github.com/clercjs/clerc/actions/workflows/autofix-ci.yml/badge.svg)](https://github.com/clercjs/clerc/actions/workflows/autofix-ci.yml)
+[![CI](https://github.com/clercjs/clerc/actions/workflows/conventional-ci.yml/badge.svg)](https://github.com/clercjs/clerc/actions/workflows/conventional-ci.yml)
 [![Downloads/week](https://img.shields.io/npm/dw/clerc.svg)](https://npmjs.org/package/clerc)
 [![License](https://img.shields.io/npm/l/clerc.svg)](https://github.com/clercjs/clerc/blob/main/package.json)
 


### PR DESCRIPTION
before:
<img width="559" height="48" alt="image" src="https://github.com/user-attachments/assets/48ce5b59-74f7-4c84-b285-ca254ec8e81e" />

in workflow folder
<img width="800" height="402" alt="image" src="https://github.com/user-attachments/assets/5db13f0f-59cd-484c-b948-c3f4e6a7dae8" />
