### PR TITLE
test: add `FORCE_COLOR=1` to produce consistent output in snapshots

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,8 @@
 import { expect } from "vitest";
 import { matchers } from "vitest-console";
 
+// Force color output for consistent snapshots
+// @uttr/tint disables colors in non-TTY environments
+process.env.FORCE_COLOR = "1";
+
 expect.extend(matchers);


### PR DESCRIPTION
before
<img width="602" height="681" alt="image" src="https://github.com/user-attachments/assets/d44d1b57-446b-44b0-8ae8-b36d7634e180" />

after
<img width="644" height="675" alt="image" src="https://github.com/user-attachments/assets/0ddcc5ee-9c5e-4331-8e04-4160372541d6" />
